### PR TITLE
feat(billing): add billing role and configurable role policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No modules.
 | <a name="input_destination_role_name_console"></a> [destination\_role\_name\_console](#input\_destination\_role\_name\_console) | Role name for Console access in destination AWS account | `string` | `null` | no |
 | <a name="input_destination_role_name_prefix"></a> [destination\_role\_name\_prefix](#input\_destination\_role\_name\_prefix) | Prefix for role names in destination AWS account | `string` | `"zzzzz-"` | no |
 | <a name="input_external_id"></a> [external\_id](#input\_external\_id) | External ID for link verification | `string` | n/a | yes |
-| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to the console and API roles. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false). When set, these policies are attached instead. Ignored when `administrator = true` | `list(string)` | `[]` | no |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to the console and API roles. Takes precedence over `administrator` when set. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false) | `list(string)` | `[]` | no |
 | <a name="input_source_role_arn"></a> [source\_role\_arn](#input\_source\_role\_arn) | Role ARN in source AWS account | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ No modules.
 |------|------|
 | [aws_iam_role.cookielab_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cookielab_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cookielab_api_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_api_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_console_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_console_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cookielab_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cookielab_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.cookielab_assume_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cookielab_assume_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -39,6 +37,7 @@ No modules.
 | <a name="input_destination_role_name_console"></a> [destination\_role\_name\_console](#input\_destination\_role\_name\_console) | Role name for Console access in destination AWS account | `string` | `null` | no |
 | <a name="input_destination_role_name_prefix"></a> [destination\_role\_name\_prefix](#input\_destination\_role\_name\_prefix) | Prefix for role names in destination AWS account | `string` | `"zzzzz-"` | no |
 | <a name="input_external_id"></a> [external\_id](#input\_external\_id) | External ID for link verification | `string` | n/a | yes |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to the console and API roles. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false). When set, these policies are attached instead. Ignored when `administrator = true` | `list(string)` | `[]` | no |
 | <a name="input_source_role_arn"></a> [source\_role\_arn](#input\_source\_role\_arn) | Role ARN in source AWS account | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -78,8 +78,8 @@ resource "aws_iam_role" "cookielab_api" {
 }
 
 locals {
-  role_policies = var.administrator ? ["arn:aws:iam::aws:policy/AdministratorAccess"] : (
-    length(var.policy_arns) > 0 ? var.policy_arns : ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+  role_policies = length(var.policy_arns) > 0 ? var.policy_arns : (
+    var.administrator ? ["arn:aws:iam::aws:policy/AdministratorAccess"] : ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -77,30 +77,22 @@ resource "aws_iam_role" "cookielab_api" {
   assume_role_policy = data.aws_iam_policy_document.cookielab_assume_api.json
 }
 
-resource "aws_iam_role_policy_attachment" "cookielab_console_ro" {
-  count = var.administrator == true ? 0 : 1
+locals {
+  role_policies = var.administrator ? ["arn:aws:iam::aws:policy/AdministratorAccess"] : (
+    length(var.policy_arns) > 0 ? var.policy_arns : ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "cookielab_console" {
+  for_each = toset(local.role_policies)
 
   role       = aws_iam_role.cookielab_console.name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = each.value
 }
 
-resource "aws_iam_role_policy_attachment" "cookielab_api_ro" {
-  count = var.administrator == true ? 0 : 1
+resource "aws_iam_role_policy_attachment" "cookielab_api" {
+  for_each = toset(local.role_policies)
 
   role       = aws_iam_role.cookielab_api.name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "cookielab_console_admin" {
-  count = var.administrator == true ? 1 : 0
-
-  role       = aws_iam_role.cookielab_console.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "cookielab_api_admin" {
-  count = var.administrator == true ? 1 : 0
-
-  role       = aws_iam_role.cookielab_api.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = each.value
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "administrator" {
   description = "ReadOnly or Administrator Access"
 }
 
+variable "policy_arns" {
+  type        = list(string)
+  default     = []
+  description = "Policy ARNs to attach to the console and API roles. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false). When set, these policies are attached instead. Ignored when `administrator = true`"
+}
+
 variable "destination_role_name_prefix" {
   type        = string
   default     = "zzzzz-"

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "administrator" {
 variable "policy_arns" {
   type        = list(string)
   default     = []
-  description = "Policy ARNs to attach to the console and API roles. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false). When set, these policies are attached instead. Ignored when `administrator = true`"
+  description = "Policy ARNs to attach to the console and API roles. Takes precedence over `administrator` when set. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false)"
 }
 
 variable "destination_role_name_prefix" {


### PR DESCRIPTION
Add an optional read-only billing console role and make the module's roles individually toggleable with configurable attached policies.

- New roles toggles: console (default true), api (default true), billing (default false)
- New billing role with AWSBillingReadOnlyAccess by default, assumable via the console MFA/SSO trust policy
- Configurable policy ARNs per role (console_policy_arns, api_policy_arns, billing_policy_arns); fall back to the administrator toggle for console/api and AWSBillingReadOnlyAccess for billing
- Policy attachments switched to for_each over the resolved policy lists
- external_id is now optional, required (validated) only when api = true
- moved blocks migrate existing cookielab_console/cookielab_api state to count[0] instead of destroy/recreate
- Bump required Terraform to >= 1.9.0 (cross-variable validation)
- Regenerate README