### PR TITLE
feat: make console/api policy attachments configurable via policy_arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ No modules.
 | [aws_iam_role.cookielab_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cookielab_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cookielab_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cookielab_api_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_api_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cookielab_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cookielab_billing_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_console_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cookielab_console_ro](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cookielab_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.cookielab_assume_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cookielab_assume_console](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -35,7 +33,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_administrator"></a> [administrator](#input\_administrator) | ReadOnly or Administrator Access | `bool` | `false` | no |
+| <a name="input_administrator"></a> [administrator](#input\_administrator) | ReadOnly or Administrator Access. Used as fallback for the console/api roles when `policy_arns` is empty | `bool` | `false` | no |
 | <a name="input_api"></a> [api](#input\_api) | Create an API access role | `bool` | `true` | no |
 | <a name="input_assume_from_sso"></a> [assume\_from\_sso](#input\_assume\_from\_sso) | List of objects containing `aws_source_account_id`, `sso_region` and `sso_permissions_set_name` to be allowed to assume console and billing roles | <pre>list(object({<br/>    aws_source_account_id    = string<br/>    sso_region               = string<br/>    sso_permissions_set_name = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_billing"></a> [billing](#input\_billing) | Create a billing role with read-only billing console access | `bool` | `false` | no |
@@ -45,6 +43,7 @@ No modules.
 | <a name="input_destination_role_name_console"></a> [destination\_role\_name\_console](#input\_destination\_role\_name\_console) | Role name for Console access in destination AWS account | `string` | `null` | no |
 | <a name="input_destination_role_name_prefix"></a> [destination\_role\_name\_prefix](#input\_destination\_role\_name\_prefix) | Prefix for role names in destination AWS account | `string` | `"zzzzz-"` | no |
 | <a name="input_external_id"></a> [external\_id](#input\_external\_id) | External ID for link verification. Required when `api = true` | `string` | `null` | no |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | Policy ARNs to attach to the console and API roles. Takes precedence over `administrator` when set. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false) | `list(string)` | `[]` | no |
 | <a name="input_source_role_arn"></a> [source\_role\_arn](#input\_source\_role\_arn) | Role ARN in source AWS account | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -83,32 +83,24 @@ resource "aws_iam_role" "cookielab_api" {
   assume_role_policy = data.aws_iam_policy_document.cookielab_assume_api[0].json
 }
 
-resource "aws_iam_role_policy_attachment" "cookielab_console_ro" {
-  count = var.console == true && var.administrator == false ? 1 : 0
+locals {
+  role_policies = length(var.policy_arns) > 0 ? var.policy_arns : (
+    var.administrator ? ["arn:aws:iam::aws:policy/AdministratorAccess"] : ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "cookielab_console" {
+  for_each = var.console == true ? toset(local.role_policies) : toset([])
 
   role       = aws_iam_role.cookielab_console[0].name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = each.value
 }
 
-resource "aws_iam_role_policy_attachment" "cookielab_api_ro" {
-  count = var.api == true && var.administrator == false ? 1 : 0
+resource "aws_iam_role_policy_attachment" "cookielab_api" {
+  for_each = var.api == true ? toset(local.role_policies) : toset([])
 
   role       = aws_iam_role.cookielab_api[0].name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "cookielab_console_admin" {
-  count = var.console == true && var.administrator == true ? 1 : 0
-
-  role       = aws_iam_role.cookielab_console[0].name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "cookielab_api_admin" {
-  count = var.api == true && var.administrator == true ? 1 : 0
-
-  role       = aws_iam_role.cookielab_api[0].name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = each.value
 }
 
 resource "aws_iam_role" "cookielab_billing" {

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,24 @@
+# Migrate the previous count-based ReadOnly/Administrator policy attachments
+# to the new for_each attachments keyed by policy ARN. Whichever attachment
+# actually exists in state (ro or admin, per the `administrator` toggle) is
+# moved; the other block is a no-op because its source is absent from state.
+
+moved {
+  from = aws_iam_role_policy_attachment.cookielab_console_ro[0]
+  to   = aws_iam_role_policy_attachment.cookielab_console["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.cookielab_console_admin[0]
+  to   = aws_iam_role_policy_attachment.cookielab_console["arn:aws:iam::aws:policy/AdministratorAccess"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.cookielab_api_ro[0]
+  to   = aws_iam_role_policy_attachment.cookielab_api["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.cookielab_api_admin[0]
+  to   = aws_iam_role_policy_attachment.cookielab_api["arn:aws:iam::aws:policy/AdministratorAccess"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,18 @@ variable "external_id" {
 variable "administrator" {
   type        = bool
   default     = false
-  description = "ReadOnly or Administrator Access"
+  description = "ReadOnly or Administrator Access. Used as fallback for the console/api roles when `policy_arns` is empty"
+}
+
+variable "policy_arns" {
+  type        = list(string)
+  default     = []
+  description = "Policy ARNs to attach to the console and API roles. Takes precedence over `administrator` when set. When empty, `administrator` selects AdministratorAccess (true) or ReadOnlyAccess (false)"
+
+  validation {
+    condition     = alltrue([for arn in var.policy_arns : can(regex("^arn:aws:iam::(aws|[[:digit:]]{12}):policy/.+", arn))])
+    error_message = "Each entry must be a valid IAM policy ARN."
+  }
 }
 
 variable "console" {


### PR DESCRIPTION
Follow-up on #33. Replace the four count-based ReadOnly/Administrator policy attachments with a single per-role `for_each` over a shared, resolved policy list.

- New optional `policy_arns` (`list(string)`, default `[]`) — attach arbitrary managed policies to the console and api roles
- When empty, falls back to the existing `administrator` toggle (AdministratorAccess vs ReadOnlyAccess) → default behaviour unchanged
- `moved` blocks migrate existing `cookielab_{console,api}_{ro,admin}` attachments to the new `for_each` addresses → no destroy/recreate
- Billing role left as-is (fixed `AWSBillingReadOnlyAccess` from #33)

`terraform validate` and `fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)